### PR TITLE
#US-689: Fix Drupal 9 compatibility

### DIFF
--- a/iq_pb_cug.module
+++ b/iq_pb_cug.module
@@ -60,6 +60,7 @@ function iq_pb_cug_node_access($node, $op, $account)
  */
 function iq_pb_cug_user_login(UserInterface $user)
 {
+    $middleware = \Drupal::service('http_middleware.iq_pb_cug');
     $isExtranet = false;
     $weight = -1;
     $username = null;
@@ -79,7 +80,7 @@ function iq_pb_cug_user_login(UserInterface $user)
             $destination = \Drupal::request()->query->get('destination');
             if (!empty($destination)) {
                 $response = new RedirectResponse(Url::fromUserInput($destination)->toString());
-                $response->send();
+                $middleware->setRedirectResponse($response);
                 return;
             }
 
@@ -94,10 +95,10 @@ function iq_pb_cug_user_login(UserInterface $user)
                 if (!empty($cug_redirection[$username])) {
                     $response = new RedirectResponse(Url::fromUserInput($cug_redirection[$username])
                             ->toString());
-                    $response->send();
+                    $middleware->setRedirectResponse($response);
                 } else if (!empty($default_redirection)) {
                     $response = new RedirectResponse(Url::fromUserInput($default_redirection)->toString());
-                    $response->send();
+                    $middleware->setRedirectResponse($response);
                 }
             }
         }

--- a/iq_pb_cug.services.yml
+++ b/iq_pb_cug.services.yml
@@ -1,0 +1,5 @@
+services:
+  http_middleware.iq_pb_cug:
+    class: Drupal\iq_pb_cug\RedirectMiddleware
+    tags:
+      - { name: http_middleware}

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\iq_pb_cug;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Url;
+
+/**
+ * Executes redirect before the main kernel takes over the request.
+ */
+class RedirectMiddleware implements HttpKernelInterface {
+
+  /**
+   * The wrapped HTTP kernel.
+   *
+   * @var \Symfony\Component\HttpKernel\HttpKernelInterface
+   */
+  protected $httpKernel;
+
+  /**
+   * The redirect URL.
+   *
+   * @var \Symfony\Component\HttpFoundation\RedirectResponse
+   */
+  protected $redirectResponse;
+
+  /**
+   * Constructs a RedirectMiddleware
+   * object.
+   *
+   * @param \Symfony\Component\HttpKernel\HttpKernelInterface $http_kernel
+   *   The decorated kernel.
+   */
+  public function __construct(HttpKernelInterface $http_kernel) {
+    $this->httpKernel = $http_kernel;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = TRUE) {
+    $response = $this->httpKernel->handle($request, $type, $catch);
+    return $this->redirectResponse ?: $response;
+  }
+
+  /**
+   * Stores the requested redirect response.
+   *
+   * @param \Symfony\Component\HttpFoundation\RedirectResponse|null $redirectResponse
+   *   Redirect response.
+   */
+  public function setRedirectResponse(?RedirectResponse $redirectResponse) {
+    $this->redirectResponse = $redirectResponse;
+  }
+
+}


### PR DESCRIPTION
## Tasks
- [x] Remove redirect in `hook_node_access()`
  * Since the hook is being called by other functions like the menu tree it will redirect whenever there is a restricted page in the menu (i.e. always)
  * Instead of redirecting to the login page and attaching a `destination` parameter, you can just set the `403` page to `/user/login` in the site settings to achieve a similar effect
- [x] Remove `node_access_rebuild()`
  * Is this really necessary?
  * It shows a message to the user when visiting a restricted page
- [x] Fix redirects in `hook_user_login()`
  * Related issue: [#3214949](https://www.drupal.org/project/redirect_after_login/issues/3214949)

## Testing Environment
* [berna1881](https://github.com/iqual-ch/berna1881-sw-project/pull/1)
* [iqual](https://github.com/iqual-ch/iqualch-sw-project/tree/issue/drupal-9) (dev branch not yet required)
* ...others?